### PR TITLE
fixed indent bug and add new indent rules

### DIFF
--- a/indent/dosbatch.vim
+++ b/indent/dosbatch.vim
@@ -35,9 +35,10 @@ function! GetDosBatchIndent(lnum)
 
   let l:ind = l:previ
 
-  if l:prevl =~? '^\s*if\>.*(' ||
-	\ l:prevl =~? '\<do\>\s*(' ||
-	\ l:prevl =~? '\<else\>\s*\%(if\>.*\)\?('
+  if l:prevl =~? '^\s*@\=if\>.*(\s*$' ||
+        \ l:prevl =~? '\<do\>\s*(\s*$' ||
+        \ l:prevl =~? '\<else\>\s*\%(if\>.*\)\?(\s*$' ||
+        \ l:prevl =~? '^.*\(&&\|||\)\s*(\s*$'
     " previous line opened a block
     let l:ind += shiftwidth()
   endif


### PR DESCRIPTION
hi, I changed the indent regexp  for correct the indentation when:

1. if 'if' expression which with '(' just in single line, don't indent the next line.

```bat
if exist "%~dp0" ( echo nothing ) else ( echo something else )
if exist "%~dp0" ( echo nothing ) else ( echo something else )
```

2. aslo indent when 'if' with a '@' like '@if'
```bat
@if exist "%~dp0" ( 
    echo nothing 
) else ( 
    echo something else 
)
```
3. indent for code like:
```bat
somecommand.exe 2>nul && (
    echo "do something"
) || (
    echo "do something else"
)
```